### PR TITLE
BODS-8250 - Fix endDate as null

### DIFF
--- a/backend/src/csv_handler/utils/db.py
+++ b/backend/src/csv_handler/utils/db.py
@@ -1,5 +1,6 @@
 import boto3
 import urllib.parse
+from datetime import date
 from os import getenv
 from sqlalchemy import create_engine, func, select, Table, case, desc, or_, and_
 from sqlalchemy.ext.automap import automap_base
@@ -662,7 +663,8 @@ class DBManager:
             )
         else:
             PDBRDGroup = None
-            
+
+        default_date = date(2100, 1, 1)
         records = (
             session.query(
                 PDBRDRegistration.registration_number.label("registrationNumber"),
@@ -678,7 +680,7 @@ class DBManager:
                 PDBRDRegistration.received_date.label("receivedDate"),
                 PDBRDRegistration.granted_date.label("grantedDate"),
                 PDBRDRegistration.effective_date.label("effectiveDate"),
-                PDBRDRegistration.end_date.label("endDate"),
+                func.coalesce(PDBRDRegistration.end_date, default_date).label("endDate"),
                 PDBRDRegistration.bus_service_type_id.label("busServiceTypeId"),
                 PDBRDRegistration.bus_service_type_description.label(
                     "busServiceTypeDescription"


### PR DESCRIPTION
# Description

When querying through `/all-records` API endpoint, the **endDate** should always return a value. Where this is `null` in the database, it should default to 01/01/2100

Fixes # (issue)
BODS-8250

## Type of Change

Please delete options that are not relevant.

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update