### PR TITLE
fix: scope check for /all-records endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # pdbrd-app
+
+## Local Setup
+
+To get your local environment set up, follow the instructions in the [setup guide](docs/setup.md).

--- a/backend/src/csv_handler/auth/verifier.py
+++ b/backend/src/csv_handler/auth/verifier.py
@@ -98,7 +98,8 @@ def token_verifier(token: str = Security(CustomHTTPBearer())):
 
 def check_is_an_app(claims: dict) -> Tuple[bool, str]:
     scope = claims.get("scope")
-    if scope:
+    is_user = scope == "aws.cognito.signin.user.admin"
+    if scope and not is_user:
         app_name = scope.split("/")[-1]
         if len(app_name) > 0:
             return True, app_name

--- a/config/.env.tpl
+++ b/config/.env.tpl
@@ -20,7 +20,7 @@ REACT_APP_SUPPORT_PHONE=01234 567890
 
 # # PostgreSQL
 # # ------------------------------------------------------------------------------
-POSTGRES_HOST=localhost
+POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,6 @@
 # Prerequisites
 * [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html)
-* [Node (v18.x.x) / npm (v9.x.x)](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+* [Node (v20.x.x) / npm (v9.x.x)](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 * [nodemon (npm Package)](https://www.npmjs.com/package//nodemon)
 * [PostgreSQL Client (psql)](https://www.postgresql.org/download/)
 * [Docker Desktop](https://www.docker.com/get-started/) **or another container runtime of your choosing**
@@ -47,7 +47,7 @@ make stop-services
 make clean-services
 ```
 
-As part of the startup of PostgreSQL, the initial project database will be created 
+As part of the startup of PostgreSQL, the initial project database will be created
 with roles defined within the `./sql/local` directory.
 
 ### Step 4: Initialise the Database Schema
@@ -94,3 +94,26 @@ terminals to be able to take full advantage of any debug logging that may
 occur as a result of running these applications. It is worth noting that 
 changes to the underlying codebase should be reflected in the already
 running application(s), without the need for additional rebuilding.
+
+### Step 6: Set Up a User Account
+
+To log into the application locally, you need a user in the Cognito User Pool and the correct environment variables
+pointing to it.
+
+Create a user in the dev Cognito User Pool via the AWS Console (Cognito → User Pools → select the dev pool → Create
+user).
+
+Update the following environment variables with the dev User Pool values:
+
+```dotenv
+# CSV Handler Lambda
+COGNITO_USERPOOL_ID=<dev-user-pool-id>
+COGNITO_APP_CLIENT_ID=<dev-app-client-id>
+
+# React Frontend
+REACT_APP_USER_POOL_ID=<dev-user-pool-id>
+REACT_APP_USER_POOL_CLIENT_ID=<dev-app-client-id>
+```
+
+Start the services (see Step 5) and navigate to `http://localhost:3000/login` — you should now be able to log in with
+the user you created.


### PR DESCRIPTION
Related to [DBODS-2209](https://busopendataservice.atlassian.net/browse/DBODS-2209)

When trying to replicate the issue described in the ticket locally, I noticed that regardless of what user I was when I download a CSV it incorrectly contains all registrations for all organisations. I believe a user should only be able to download registrations related to their own organisation. 

This code change could potentially fix CSV downloads in prod, as it should bring back a lot less data. 
